### PR TITLE
Update datepicker.component.ts

### DIFF
--- a/src/datepicker.component.ts
+++ b/src/datepicker.component.ts
@@ -535,7 +535,13 @@ export class DatepickerComponent implements OnInit, OnChanges {
       }
     }
     // check if new date would be within range
-    let newDate = new Date(newYear, newMonth);
+		let newDate;
+		if(this.rangeStart) {
+			newDate = new Date(newYear, newMonth, this.rangeStart.getDate());
+		}
+		else {
+			newDate = new Date(newYear, newMonth);
+		}
     let newDateValid: boolean;
     if (direction === 'left') {
       newDateValid = !this.rangeStart || newDate.getTime() >= this.rangeStart.getTime();


### PR DESCRIPTION
Because the newDate is making an object for the first start of the month aka 1/mm/yyyy when you try to go back to the current month it doesn't let you because newDate.getTime() < this.rangeStart.getTime()
that's because this.rangeStart is (dd-1)/mm/yyyy and dd-1>1